### PR TITLE
Error context support

### DIFF
--- a/src/jsonselect.js
+++ b/src/jsonselect.js
@@ -41,7 +41,7 @@
 
     // throw an error message
     function te(ec, context) {
-      throw new Error(errorCodes[ec] + " in '" + context + "'");
+      throw new Error(errorCodes[ec] + ( context && " in '" + context + "'"));
     }
 
     // THE LEXER

--- a/src/test/run.js
+++ b/src/test/run.js
@@ -34,23 +34,9 @@ function runOneSync(name, selname, p) {
         });
     } catch(e) {
         got = e.toString();
-        if (want.trim() != got.trim()) {
-             
-            // The error messages will have consistent prefix strings, but variant context strings
-            if ( want.trim().indexOf("Error") === -1 && got.trim().indexOf( want.trim() ) !== 0 ) {
-              throw e;
-            }
-            //console.log( "want: " + want.trim() );
-            //console.log( "got: " + got.trim() );
-        }
+        if (want.trim() != got.trim()) throw e;
     }
-    if (want.trim() != got.trim()) {
-      //console.log( "want: " + want.trim() );
-      //console.log( "got: " + got.trim() );    
-      if ( want.trim().indexOf("Error") === -1 && got.trim().indexOf( want.trim() ) !== 0 ) {
-        throw "mismatch";                       
-      }
-    }
+    if (want.trim() != got.trim()) throw "mismatch";
 }
 
 

--- a/src/test/run.js
+++ b/src/test/run.js
@@ -34,9 +34,23 @@ function runOneSync(name, selname, p) {
         });
     } catch(e) {
         got = e.toString();
-        if (want.trim() != got.trim()) throw e;
+        if (want.trim() != got.trim()) {
+             
+            // The error messages will have consistent prefix strings, but variant context strings
+            if ( want.trim().indexOf("Error") === -1 && got.trim().indexOf( want.trim() ) !== 0 ) {
+              throw e;
+            }
+            //console.log( "want: " + want.trim() );
+            //console.log( "got: " + got.trim() );
+        }
     }
-    if (want.trim() != got.trim()) throw "mismatch";
+    if (want.trim() != got.trim()) {
+      //console.log( "want: " + want.trim() );
+      //console.log( "got: " + got.trim() );    
+      if ( want.trim().indexOf("Error") === -1 && got.trim().indexOf( want.trim() ) !== 0 ) {
+        throw "mismatch";                       
+      }
+    }
 }
 
 


### PR DESCRIPTION
I tried to add the closest contextual strings as a second arg to the `te()` method.

`te( errorCode [, contextStr ] )`
