### PR TITLE
Add link to fully-conformant Python implementation

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,7 +120,7 @@ return undefined;</pre>
         <p class="item"><b>node.js:</b> <tt>npm install JSONSelect</tt></p>
         <p class="item"><b>ruby:</b> A gem by <a href="https://github.com/fd">Simon Menke</a>: <a href="https://github.com/fd/json_select">https://github.com/fd/json_select</a></p>
         <p class="item"><b>go:</b> A <a href="https://github.com/latestrevision/go-jsonselect">go implementation</a> by <a href="https://github.com/latestrevision">Adam Coddington</a>
-        <p class="item"><b>python:</b> A <a href="https://github.com/mwhooker/jsonselect">python port</a> by <a href="https://github.com/mwhooker">Matthew Hooker</a>
+        <p class="item"><b>python:</b> <a href="https://github.com/danvk/pyjsonselect/">pyjsonselect</a> (fully conformant) by <a href="https://github.com/danvk">Dan Vanderkam</a> and <a href="https://github.com/mwhooker/jsonselect">jsonselect</a> (level 2 conformant) by <a href="https://github.com/mwhooker">Matthew Hooker</a>
         <p class="item"><b>couchdb:</b> JSONSelect <a href="https://github.com/ryanramage/couchdb-jsonselect">integration for couchdb</a> by <a href="https://github.com/ryanramage">Ryan Ramage</a>
         <p class="item"><b>php:</b> A <a href="https://github.com/observu/JSONselect-php">php implementation</a> by <a href="https://github.com/observu">@observu</a>
         <p class="psst">

--- a/index.html
+++ b/index.html
@@ -120,7 +120,7 @@ return undefined;</pre>
         <p class="item"><b>node.js:</b> <tt>npm install JSONSelect</tt></p>
         <p class="item"><b>ruby:</b> A gem by <a href="https://github.com/fd">Simon Menke</a>: <a href="https://github.com/fd/json_select">https://github.com/fd/json_select</a></p>
         <p class="item"><b>go:</b> A <a href="https://github.com/latestrevision/go-jsonselect">go implementation</a> by <a href="https://github.com/latestrevision">Adam Coddington</a>
-        <p class="item"><b>python:</b> <a href="https://github.com/danvk/pyjsonselect/">pyjsonselect</a> (fully conformant) by <a href="https://github.com/danvk">Dan Vanderkam</a> and <a href="https://github.com/mwhooker/jsonselect">jsonselect</a> (level 2 conformant) by <a href="https://github.com/mwhooker">Matthew Hooker</a>
+        <p class="item"><b>python:</b> <a href="https://github.com/danvk/pyjsonselect/">pyjsonselect</a> by <a href="https://github.com/danvk">Dan Vanderkam</a>
         <p class="item"><b>couchdb:</b> JSONSelect <a href="https://github.com/ryanramage/couchdb-jsonselect">integration for couchdb</a> by <a href="https://github.com/ryanramage">Ryan Ramage</a>
         <p class="item"><b>php:</b> A <a href="https://github.com/observu/JSONselect-php">php implementation</a> by <a href="https://github.com/observu">@observu</a>
         <p class="psst">


### PR DESCRIPTION
I published pyjsonselect earlier today -- it's a direct port of the JavaScript reference implementation, and hence fully conformant.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/lloyd/jsonselect/63)

<!-- Reviewable:end -->
